### PR TITLE
Fix fields default value

### DIFF
--- a/src/Pages/ModelSettingsPage.php
+++ b/src/Pages/ModelSettingsPage.php
@@ -42,7 +42,7 @@ class ModelSettingsPage extends Page implements HasForms
         $data = $this->mutateFormDataBeforeFill($settings->all());
 
         /** @phpstan-ignore-next-line */
-        $this->form->fill($data);
+        $this->form->fill(blank($data) ? null : $data);
 
         $this->callHook('afterFill');
     }


### PR DESCRIPTION
This PR fixes the default value for the form components when there is no data saved. It checks if the data is empty and sets `null` to ensure the default values work properly.