### PR TITLE
Allow customization of settings persistence

### DIFF
--- a/src/Pages/ModelSettingsPage.php
+++ b/src/Pages/ModelSettingsPage.php
@@ -10,6 +10,7 @@ use Filament\Notifications\Notification;
 use Filament\Pages\Concerns;
 use Filament\Pages\Page;
 use Filament\Support\Exceptions\Halt;
+use Glorand\Model\Settings\Contracts\SettingsManagerContract;
 use Quadrubo\FilamentModelSettings\Exceptions\HasModelSettingsNotImplementedException;
 use Quadrubo\FilamentModelSettings\Pages\Contracts\HasModelSettings;
 
@@ -74,9 +75,7 @@ class ModelSettingsPage extends Page implements HasForms
 
             $this->callHook('beforeSave');
 
-            $settings = $this->getSettingRecord()->settings();
-
-            $settings->apply((array) $data);
+            $this->handleRecordUpdate($this->getSettingRecord()->settings(), $data);
 
             $this->callHook('afterSave');
         } catch (Halt $exception) {
@@ -115,6 +114,14 @@ class ModelSettingsPage extends Page implements HasForms
     protected function mutateFormDataBeforeSave(array $data): array
     {
         return $data;
+    }
+
+    /**
+     * @param  array<string, mixed>  $data
+     */
+    protected function handleRecordUpdate(SettingsManagerContract $settings, array $data): SettingsManagerContract
+    {
+        return $settings->apply((array) $data);
     }
 
     /**


### PR DESCRIPTION
# Summary
This aligns the package to the standard persistence functionality abstraction allowance akin to the EditRecord page within Filament Panel src, see ref: https://github.com/filamentphp/filament/blob/5a8b9994e9356a0d0702b7c307d811496440ef12/packages/panels/src/Resources/Pages/EditRecord.php#L151

## Why
This came as I would like an override to provide update-like behavior instead of the included `->apply((array)` behavior. (so basically instead- I would use `$settings->setMultiple(Arr::dot($data));` within the `handleRecordUpdate` I define)

Edit:
(This ~workaround~ produces the desired "updating"-like functionality)
```php
<?php

namespace App\Filament\Pages;

use Quadrubo\FilamentModelSettings\Pages\Contracts\HasModelSettings;
use Quadrubo\FilamentModelSettings\Pages\ModelSettingsPage as Page;

abstract class ModelSettingsPage extends Page implements HasModelSettings
{
    /**
     * @param  array<string, mixed>  $data
     * @return array<string, mixed>
     */
    protected function mutateFormDataBeforeSave(array $data): array
    {
        $settings = $this->getSettingRecord()->settings();

        // I want to merge the changes ($data) with the existing settings $settings->allFlattened(), allowing this to act as an "update" operation instead of "apply" from the package.
        return array_merge($settings->allFlattened(), $settings::dotFlatten($data));
    }
}

``` 